### PR TITLE
support config description in -print-defaults

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,27 @@
+# Driplimit default configuration
+# ADDR: address to listen on
+ADDR=127.0.0.1
+# CACHE_DURATION: cache entries time-to-live
+CACHE_DURATION=30s
+# DATABASE_NAME: database file name
+DATABASE_NAME=driplimit.db
+# DATA_DIR: directory where the database file is stored
+DATA_DIR=
+# GZIP_COMPRESSION: enable gzip compression
+GZIP_COMPRESSION=false
+# KEYS_CACHE_SIZE: maximum number of keys in the cache
+KEYS_CACHE_SIZE=65536
+# LOG_FORMAT: log format (text or json)
+LOG_FORMAT=text
+# LOG_SEVERITY: log severity level (debug, info, warn, error)
+LOG_SEVERITY=info
+# MODE: service mode (authoritative, async_authoritative, proxy)
+MODE=authoritative
+# PORT: port to listen on
+PORT=7131
+# SERVICE_KEYS_CACHE_SIZE: maximum number of service keys in the cache
+SERVICE_KEYS_CACHE_SIZE=2048
+# UPSTREAM_TIMEOUT: timeout for upstream requests
+UPSTREAM_TIMEOUT=5s
+# UPSTREAM_URL: upstream URL for proxy mode or SDK client
+UPSTREAM_URL=

--- a/pkg/client/http.go
+++ b/pkg/client/http.go
@@ -24,15 +24,15 @@ type httpClient struct {
 func New(cfg *config.Config) driplimit.ServiceWithToken {
 	transport := &http.Transport{
 		Dial: (&net.Dialer{
-			Timeout: cfg.Timeout,
+			Timeout: cfg.UpstreamTimeout,
 		}).Dial,
-		TLSHandshakeTimeout: cfg.Timeout,
+		TLSHandshakeTimeout: cfg.UpstreamTimeout,
 	}
 
 	return &httpClient{
 		cfg: cfg,
 		client: &http.Client{
-			Timeout:   cfg.Timeout,
+			Timeout:   cfg.UpstreamTimeout,
 			Transport: transport,
 		},
 		logger: cfg.Logger().With("component", "client"),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,9 +13,7 @@ func TestDefaults(t *testing.T) {
 	cfg := new(config.Config)
 	deflt, err := cfg.Defaults()
 	assert.NoError(t, err)
-	assert.Contains(t, deflt, "PORT")
-	assert.Contains(t, deflt, "LOG_SEVERITY")
-	assert.Equal(t, "7131", deflt["PORT"])
+	assert.Equal(t, config.ConfigHelp{Default: "127.0.0.1", Description: "address to listen on"}, deflt["ADDR"])
 }
 
 func TestFromEnvFile(t *testing.T) {


### PR DESCRIPTION
`-print-defaults` now add config description in comment

```bash
# Driplimit default configuration
# ADDR: address to listen on
ADDR=127.0.0.1
# CACHE_DURATION: cache entries time-to-live
CACHE_DURATION=30s
# DATABASE_NAME: database file name
DATABASE_NAME=driplimit.db
# DATA_DIR: directory where the database file is stored
DATA_DIR=
# GZIP_COMPRESSION: enable gzip compression
GZIP_COMPRESSION=false
# KEYS_CACHE_SIZE: maximum number of keys in the cache
KEYS_CACHE_SIZE=65536
# LOG_FORMAT: log format (text or json)
LOG_FORMAT=text
# LOG_SEVERITY: log severity level (debug, info, warn, error)
LOG_SEVERITY=info
# MODE: service mode (authoritative, async_authoritative, proxy)
MODE=authoritative
# PORT: port to listen on
PORT=7131
# SERVICE_KEYS_CACHE_SIZE: maximum number of service keys in the cache
SERVICE_KEYS_CACHE_SIZE=2048
# UPSTREAM_TIMEOUT: timeout for upstream requests
UPSTREAM_TIMEOUT=5s
# UPSTREAM_URL: upstream URL for proxy mode or SDK client
UPSTREAM_URL=
```